### PR TITLE
low res feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This map editor should make it fairly easy to create and share maps for "War for
 
 #### Upcoming Features:
 - [ ] Resizing of current Map
-- [ ] GUI for custom tile size (default is now 64)
+- [x] GUI for custom tile size (default is now 64)
 - [ ] Mirror map vertical/horizontal
-- [ ] Low-Res version for slower connections
-- [ ] Save Configuration with localStorage/Cookies
+- [x] ~~Low-Res~~ Color version for slower connections
+- [x] Save Configuration with localStorage/Cookies
 - [x] Preload tiles
 - [x] Information of current tile

--- a/css/style.css
+++ b/css/style.css
@@ -86,3 +86,7 @@ td:hover {
 .toolBox32, .toolBox32 input, .toolBox32 button {
 	font-size: 10px !important;
 }
+
+#general * {
+	margin: 2px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,12 +1,12 @@
 * {
 	font-family: Verdana, Tahoma, "San Serif";
-	font-size: 12px;
 }
 
 html, body {
 	background: #111;
 	margin: 0;
 	padding: 0;
+	font-size: 12px;
 }
 
 p{
@@ -77,4 +77,12 @@ td:hover {
 
 #info {
 	margin: 5px;
+}
+
+.toolBox24, .toolBox24 input, .toolBox24 button {
+	font-size: 9px !important;
+}
+
+.toolBox32, .toolBox32 input, .toolBox32 button {
+	font-size: 10px !important;
 }

--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
 		<!-- input type="text" id="author" placeholder="Your Name" / -->
 		<a href="#" id="export" onclick="exportMap()"><button>Export</button></a>
 	</fieldset>
+	<fieldset id="general">
+		<legend>General Options</legend>
+		<input type="button" id="saveOptions" onclick="saveOptions()" value="Save options" />
+		<input type="button" id="resetOptions" onclick="resetOptions()" value="Reset options" />
+	</fieldset>
 	<input style="float: right" type="button" value="Close" onclick="toggleOptions(false)" />
 </div>
 </body>

--- a/js/editor.js
+++ b/js/editor.js
@@ -20,6 +20,7 @@ function Map(sizex, sizey) {
 	this.assetDir = './tiles/';
 	this.preloadImages = true;
 	this.buttonColumns = 2;
+	this.tileMode = "highres";
 
 	var mapParent = document.getElementsByTagName('body')[0];
 
@@ -29,21 +30,23 @@ function Map(sizex, sizey) {
 		for (var item in tiles) {
 			var posx = tiles[item].sizex;
 			var posy = tiles[item].sizey;
+			var css = map.tileMode == "color" ? ' { background-color: ' + tiles[item].color + '; }\n' : ' { background-image: url("' + map.assetDir + item + '.png"); }\n';
 			style.innerHTML += '/* ' + posx + ' x ' + posy + ' */\n';
-			style.innerHTML += '.' + item + ' { background-image: url("' + map.assetDir + item + '.png"); }\n';
+			style.innerHTML += '.' + item + css;
 		}
 		document.getElementsByTagName('head')[0].appendChild(style);
 	}
 
 	this.preloadTiles = function(callback) {
-		var image = [], loadedImages=0;
 		var images = Object.keys(tiles);
-		var start = new Date();
-		if (!images || !map.preloadImages) {
+		
+		if (!images || !map.preloadImages || map.tileMode == "color") {
 			// browser doesn't support this, so we just skip it
 			callback.call(this);
 			return;
 		}
+		var image = [], loadedImages=0;
+		var start = new Date();
 		var preloadDiv = document.getElementById("preload");
 		var preloadMessage = preloadDiv.getAttribute("data-message");
 		

--- a/js/editor.js
+++ b/js/editor.js
@@ -20,13 +20,25 @@ function Map(sizex, sizey) {
 	this.assetDir = './tiles/';
 	this.preloadImages = true;
 	this.buttonColumns = 2;
-	this.tileMode = "highres";
+	this.tileMode = 'highres';
+	this.tileModes = [ 'color', 'highres' ];
 
 	var mapParent = document.getElementsByTagName('body')[0];
 
+	this.setTileMode = function(tileMode) {
+		if (map.tileModes.indexOf(tileMode) == -1) {
+			throw new Error("The tilemode " + tileMode + " is not allowed!");
+			return;
+		}
+		map.tileMode = tileMode;
+		map.generateTileCss();
+	}
+	
 	this.generateTileCss = function() {
-		var style = document.createElement('style');
+		var style = document.getElementById('tileCss') || document.createElement('style');
+		style.id = 'tileCss';
 		style.type = 'text/css';
+		style.innerHTML = '';
 		for (var item in tiles) {
 			var posx = tiles[item].sizex;
 			var posy = tiles[item].sizey;

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,5 +1,6 @@
 window.onload = function(){
 	terrain = new Map();
+	terrain.getQueryOptions();
 	terrain.preloadTiles(function(){
 		terrain.generateTileCss();
 		terrain.init();
@@ -40,22 +41,35 @@ function Map(sizex, sizey) {
 
 	var mapParent = document.getElementsByTagName('body')[0];
 
+	this.getQueryOptions = function() {
+		for (var item in map.options) {
+			var option = map.options[item].option;
+			var postSave = map.options[item].postSave;
+			var match = location.search.match('(^\\?|&)'+option+'=([^\\?&=]+)');
+			if (match) {
+				map[postSave](match[2]);
+			}
+		}
+	}
+	
 	// TODO: Implement to save dom operations
 	this.setTileMode = function(tileMode) {
 		if (map.tileModes.indexOf(tileMode) == -1) {
-			throw new Error("The tilemode " + tileMode + " is not allowed!");
+			console.error("The tilemode " + tileMode + " is not allowed!");
 			return;
 		}
+		localStorage.setItem("tileMode", tileMode);
 		map.tileMode = tileMode;
-		map.generateTileCss();
+		//map.generateTileCss();
 	}
 	
 	// TODO: Implement to save dom operations
 	this.setTileSize = function(tileSize) {
 		if (map.tileSizes.indexOf(parseInt(tileSize)) == -1) {
-			throw new Error("The tileSize " + parseInt(tileSize) + " is not allowed!");
+			console.error("The tileSize " + parseInt(tileSize) + " is not allowed!");
 			return;
 		}
+		localStorage.setItem("tileSize", tileSize);
 		map.tileSize = tileSize;
 		// TODO: implement instant change of tilesize
 	}

--- a/js/options.js
+++ b/js/options.js
@@ -2,11 +2,11 @@ function newMap(sizex, sizey) {
 	sizex = parseInt(document.getElementById("width").value);
 	sizey = parseInt(document.getElementById("height").value);
 	if (!isNaN(sizex) && !isNaN(sizey)) {
-		if (sizex >= 5 && sizey >= 5) {
+		if (sizex >= 5 && sizey >= 5 && sizex <= 130 && sizey <= 130) {
 			terrain = new Map(sizex, sizey);
 			terrain.init();
 		} else {
-			alert("A valid map has to at least 5 by 5!");
+			alert("A valid map has to at least 5 by 5 and 130 by 130 max");
 			return;
 		}
 	} else {

--- a/js/options.js
+++ b/js/options.js
@@ -100,7 +100,6 @@ function resetOptions() {
 	var map = terrain.export();
 	terrain.resetToDefault();
 	terrain.import(map);
-	location.search = "";
 	toggleOptions(false);
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -100,6 +100,7 @@ function resetOptions() {
 	var map = terrain.export();
 	terrain.resetToDefault();
 	terrain.import(map);
+	location.search = "";
 	toggleOptions(false);
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -113,7 +113,7 @@ function refreshOptions() {
 	for (var item in terrain.options) {
 		var label = document.createElement("label");
 		label["for"] = item;
-		label.innerHTML = item + ": ";
+		label.innerHTML = terrain.options[item].option + ": ";
 		generalOptions.appendChild(label);
 		var type = terrain.options[item].type;
 		var optionvalue = terrain.options[item].option;

--- a/js/options.js
+++ b/js/options.js
@@ -65,9 +65,84 @@ function importMap() {
 	toggleOptions(false);
 }
 
+function saveOptions() {
+	// save terrain temporary
+	var map = terrain.export();
+	for (var item in terrain.options) {
+		var element = document.getElementById(item);
+		switch(element.nodeName.toLowerCase()) {
+			case 'select':
+				var value = element[element.selectedIndex].value;
+				break;
+		}
+		// save it to local storage
+		var option = terrain.options[item].option;
+		localStorage.setItem(option, value);
+		terrain[option] = value;
+		// execute post action
+		// terrain[terrain.options[item].postSave](value);
+
+	}
+	// apply possible changes
+	terrain.generateTileCss();
+	terrain.import(map);
+	
+	toggleOptions(false);
+}
+
+function resetOptions() {
+	localStorage.clear();
+	/*for (var item in terrain.options) {
+		var option = terrain[terrain.options[item].option + "Default"];
+		// execute post action
+		terrain[terrain.options[item].postSave](option);
+	}*/
+	var map = terrain.export();
+	terrain.resetToDefault();
+	terrain.import(map);
+	toggleOptions(false);
+}
+
+function refreshOptions() {
+	var generalOptions = document.getElementById("generalOptions") || document.createElement("div");
+	generalOptions.id = "generalOptions";
+	var general = document.getElementById("general");
+	var saveOptions = document.getElementById("saveOptions");
+	generalOptions.innerHTML = "";
+	for (var item in terrain.options) {
+		var label = document.createElement("label");
+		label["for"] = item;
+		label.innerHTML = item + ": ";
+		generalOptions.appendChild(label);
+		var type = terrain.options[item].type;
+		var optionvalue = terrain.options[item].option;
+		switch (type) {
+			case "select":
+				var element = document.createElement("select");
+				element.id = item;
+				for (var i = 0; i < terrain[item].length; i++) {
+					var option = document.createElement("option");
+					option.innerHTML = terrain[item][i];
+					option.value = terrain[item][i];
+					if (terrain[item][i] == terrain[optionvalue]) {
+						option.selected = "selected";
+					}
+					element.appendChild(option);
+				}
+				break;
+		}
+		generalOptions.appendChild(element);
+		generalOptions.appendChild(document.createElement("br"));
+	}
+	general.insertBefore(generalOptions, saveOptions);
+}
+
 function toggleOptions(show) {
 	var options = document.getElementById("options");
 	options.style.display = show ? "block" : "none";
 	
-	show && document.getElementById("width").focus();
+	if (show) {
+		refreshOptions();
+		document.getElementById("width").focus();
+	}
 }

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -1,91 +1,113 @@
 var tiles = {
 	'core_p1': {
 		sizex: 5,
-		sizey: 5
+		sizey: 5,
+		color: "plum"
 	},
 	'claimed_earth_p1': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "pink"
 	},
 	'core_p2': {
 		sizex: 5,
-		sizey: 5
+		sizey: 5,
+		color: "darkblue"
 	},
 	'claimed_earth_p2': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "royalblue"
 	},
 	'core_p3': {
 		sizex: 5,
-		sizey: 5
+		sizey: 5,
+		color: "green"
 	},
 	'claimed_earth_p3': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "olive"
 	},
 	'core_p4': {
 		sizex: 5,
-		sizey: 5
+		sizey: 5,
+		color: "orangered"
 	},
 	'claimed_earth_p4': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "orange"
 	},
 	'earth': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "rgb(119, 66, 1)"
 	},
 	'impenetrable': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "dimgrey"
 	},
 	'water': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "blue"
 	},
 	'permafrost': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "aqua"
 	},
 	'lava': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "darkred"
 	},
 	'dirt': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "saddlebrown"
 	},
 	'sacred_earth': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "#c0c0c0"
 	},
 	'gold': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "goldenrod"
 	},
 	'brimstone': {
 		sizex: 1,
-		sizey: 1
+		sizey: 1,
+		color: "firebrick"
 	},
 	'gateway': {
 		sizex: 3,
-		sizey: 3
+		sizey: 3,
+		color: "blueviolet"
 	},
 	'goldshrine': {
 		sizex: 3,
-		sizey: 3
+		sizey: 3,
+		color: "darkgoldenrod"
 	},
 	'archiveshrine': {
 		sizex: 3,
-		sizey: 3
+		sizey: 3,
+		color: "darkmagenta"
 	},
 	'manashrine': {
 		sizex: 3,
-		sizey: 3
+		sizey: 3,
+		color: "midnightblue"
 	},
 	'siegeshrine': {
 		sizex: 3,
-		sizey: 3
+		sizey: 3,
+		color: "darkslateblue"
 	},
 	/*
 	Still missing:


### PR DESCRIPTION
This should add support for colors instead of asset pictures, which should reduce the loading overhead drastically. The following things should be implement to make this feature complete.
- [x] General support for colors
- [x] Option for changing tile modes
- [x] Implement change of tile modes via query string (document.location.hash probably)
- [x] Implement change of tile sizes via query string 
- [x] ~~Considerate loading of custom tile color schemes~~ should be easily implemented later on (filereader and json and save it with localstorage)
- [x] Considerate low resolution image assets as possible feature in the future
- [x] Option to change the tilesize dynamicly
- [x] Save/load options (cookie/localStorage)
