### PR TITLE
mirroring a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # wfto-mapeditor
 This map editor should make it fairly easy to create and share maps for "War for the Overworld"
 
-### Release 1.0
-#### Features:
-- Big rooms (bigger than 1x1) are getting destroyed if the user draws onto it.
-- Export/Import of created Maps (Extension .wfto)
-- Creating a Path by holding the left mousebutton and moving the mouse (Only works for 1x1 tiles)
+### Release 1.1
+#### New Features:
+- GUI for custom tile size (default is now 64)
+- Mirror map vertical/horizontal
+	- Reverse lets you mirror the map reverse (1 & 2 are mirrored to 3 (2) and 4 (1) instead of 3 (1) and 4 (2))
+	- Extend Map lets you extend your map (You can use the whole map and then make it 4 times bigger with Mirror Option 1)
+- Color version for slower connections
+- Save Configuration with localStorage/Cookies
+- Preload tiles
+- Information of current tile
 
 #### Known Issues:
 - Bigger rooms are not shown if the cursor is too close the border (as they are not placeable anyway)
@@ -20,12 +25,12 @@ This map editor should make it fairly easy to create and share maps for "War for
 		- Stone
 		- Wood
 	- Sand
+	
+### Release 1.0
+#### Features:
+- Big rooms (bigger than 1x1) are getting destroyed if the user draws onto it.
+- Export/Import of created Maps (Extension .wfto)
+- Creating a Path by holding the left mousebutton and moving the mouse (Only works for 1x1 tiles)
 
 #### Upcoming Features:
 - [ ] Resizing of current Map
-- [x] GUI for custom tile size (default is now 64)
-- [x] Mirror map vertical/horizontal
-- [x] ~~Low-Res~~ Color version for slower connections
-- [x] Save Configuration with localStorage/Cookies
-- [x] Preload tiles
-- [x] Information of current tile

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This map editor should make it fairly easy to create and share maps for "War for
 #### Upcoming Features:
 - [ ] Resizing of current Map
 - [x] GUI for custom tile size (default is now 64)
-- [ ] Mirror map vertical/horizontal
+- [x] Mirror map vertical/horizontal
 - [x] ~~Low-Res~~ Color version for slower connections
 - [x] Save Configuration with localStorage/Cookies
 - [x] Preload tiles

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wfto-mapeditor
+﻿# wfto-mapeditor
 This map editor should make it fairly easy to create and share maps for "War for the Overworld"
 
 ### Release 1.1
@@ -11,8 +11,18 @@ This map editor should make it fairly easy to create and share maps for "War for
 - Save Configuration with localStorage/Cookies
 - Preload tiles
 - Information of current tile
+	
+### Release 1.0
+#### Features:
+- Big rooms (bigger than 1x1) are getting destroyed if the user draws onto it.
+- Export/Import of created Maps (Extension .wfto)
+- Creating a Path by holding the left mousebutton and moving the mouse (Only works for 1x1 tiles)
 
-#### Known Issues:
+### Upcoming Features:
+- [ ] Resizing of current Map
+- [ ] Rotate Mirror 1 Feature
+
+### Known Issues:
 - Bigger rooms are not shown if the cursor is too close the border (as they are not placeable anyway)
 - Several placeholder tiles (like the ugly dungeon cores)
 - Several missing tiles, like:
@@ -25,12 +35,3 @@ This map editor should make it fairly easy to create and share maps for "War for
 		- Stone
 		- Wood
 	- Sand
-	
-### Release 1.0
-#### Features:
-- Big rooms (bigger than 1x1) are getting destroyed if the user draws onto it.
-- Export/Import of created Maps (Extension .wfto)
-- Creating a Path by holding the left mousebutton and moving the mouse (Only works for 1x1 tiles)
-
-#### Upcoming Features:
-- [ ] Resizing of current Map

--- a/css/style.css
+++ b/css/style.css
@@ -90,3 +90,29 @@ td:hover {
 #general * {
 	margin: 2px;
 }
+
+#mirrorMap {
+	display: inline-block;
+}
+
+#mirrorMap td {
+	padding: 5px;
+	transition: all 0.3s;
+}
+
+#mirrorMap td.active {
+	background-color: #ccc;
+	cursor: pointer;
+}
+
+.mirrorVertical {
+	transform: scale(1, -1);
+}
+
+.mirrorHorizontal {
+	transform: scale(-1, 1);
+}
+
+.mirrorBoth {
+	transform: scale(-1, -1);
+}

--- a/css/style.css
+++ b/css/style.css
@@ -100,6 +100,10 @@ td:hover {
 	transition: all 0.3s;
 }
 
+#mirrorMap tr {
+	transition: all 0.3s;
+}
+
 #mirrorMap td.active {
 	background-color: #ccc;
 	cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -46,6 +46,21 @@
 		<input type="button" id="saveOptions" onclick="saveOptions()" value="Save options" />
 		<input type="button" id="resetOptions" onclick="resetOptions()" value="Reset options" />
 	</fieldset>
+	<fieldset>
+		<legend>Mirror Map</legend>
+		<table id="mirrorMap" border="1" cellspacing="0" cellpadding="0">
+			<tr>
+				<td id="first">1</td><td id="second">2</td>
+			</tr>
+			<tr>
+				<td id="third">3</td><td id="fourth">4</td>
+			</tr>
+		</table>
+		<input id="reverse" type="checkbox" value="reverse" />
+		<label for="reverse">Reverse</label>
+		<a href="#" id="mirrorButton" onclick="mirrorMap()"><button>Mirror map</button></a>
+	</fieldset>
+
 	<input style="float: right" type="button" value="Close" onclick="toggleOptions(false)" />
 </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -56,11 +56,15 @@
 				<td id="third">3</td><td id="fourth">4</td>
 			</tr>
 		</table>
-		<input id="reverse" type="checkbox" value="reverse" />
-		<label for="reverse">Reverse</label>
-		<input id="extend" type="checkbox" value="extend" />
-		<label for="extend">Extend Map</label>
-		<a href="#" id="mirrorButton" onclick="mirrorMap()"><button>Mirror map</button></a>
+		<div style="display: inline-block">
+			<input id="reverse" type="checkbox" value="reverse" />
+			<label for="reverse">Reverse</label><br />
+			<input id="extend" type="checkbox" value="extend" />
+			<label for="extend">Extend Map</label>
+		</div>
+		<div style="display: inline-block">
+			<a href="#" id="mirrorButton" onclick="mirrorMap()"><button>Mirror map</button></a>
+		</div>
 	</fieldset>
 
 	<input style="float: right" type="button" value="Close" onclick="toggleOptions(false)" />

--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@
 		</table>
 		<input id="reverse" type="checkbox" value="reverse" />
 		<label for="reverse">Reverse</label>
+		<input id="extend" type="checkbox" value="extend" />
+		<label for="extend">Extend Map</label>
 		<a href="#" id="mirrorButton" onclick="mirrorMap()"><button>Mirror map</button></a>
 	</fieldset>
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -523,15 +523,16 @@ function Map(sizex, sizey) {
 		var mapObject = map.mapToJson();
 		switch(mirrorType) {
 			case 'first':
-				// mirror 1 to 2
-				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length / 2), "vertical", reverse);
+				// mirror 1 & 3 to 2 & 4
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length), "vertical", reverse);
 				// mirror 1 & 2 to 3 & 4
 				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal", reverse);
 				break;
-			case 'second': // 1 + 2
+			case 'second': // 1 & 2 to 3 & 4
 				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal", reverse);
 				break;
-			case 'third': // 1 + 3
+			case 'third': // 1 & 3 to 2 & 4
+			default:
 				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length), "vertical", reverse);
 				break;
 		}

--- a/js/editor.js
+++ b/js/editor.js
@@ -186,7 +186,7 @@ function Map(sizex, sizey) {
 		table.setAttribute('cellpadding', '0');
 		table.setAttribute('cellspacing', '0');
 		
-		map.setHtml("mapsize", map.mapsizey + "x" + map.mapsizex);
+		map.setHtml("mapsize", map.mapsizex + "x" + map.mapsizey);
 		
 		for (var i = 0; i < map.mapsizey + (map.borderSize * 2); i++) {		
 			var tr = document.createElement("tr");

--- a/js/editor.js
+++ b/js/editor.js
@@ -575,7 +575,9 @@ function Map(sizex, sizey) {
 			// clone the mapobject cell
 			var mirrorPart = JSON.parse(JSON.stringify(mapObject.map[row][col]));
 			var posy = mirrorPart['data-pos-y'];
+			var newPosy = 0;
 			var posx = mirrorPart['data-pos-x'];
+			var newPosx = 0;
 			var newCol = mapObject.map[0].length - 1 - col;
 			var newHCol = reverse ? (x2 - 1 - col) : col;
 			var newRow = mapObject.map.length - 1 - row;
@@ -600,18 +602,27 @@ function Map(sizex, sizey) {
 				// newId = true;
 			}
 			
+			if (posx && posy) {
+				newPosx = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posx - 1;
+				newPosy = tiles[mapObject.tiles[mirrorPart['tile']]].sizey - posy - 1;
+			}
+			
 			if (type == "horizontal") {
 				// fix tileposition
+				if (reverse && posx){
+					mirrorPart['data-pos-x'] = newPosx;
+				}
 				if (posy) {
-					posy = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posy - 1;
-					mirrorPart['data-pos-y'] = posy;
+					mirrorPart['data-pos-y'] = newPosy;
 				}
 				mapObject.map[newRow][newHCol] = mirrorPart;
 			} else {
 				// fix tileposition
+				if (reverse && posy){
+					mirrorPart['data-pos-y'] = newPosy;
+				}
 				if (posx) {
-					posx = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posx - 1;
-					mirrorPart['data-pos-x'] = posx;
+					mirrorPart['data-pos-x'] = newPosx;
 				}
 				mapObject.map[newVRow][newCol] = mirrorPart;
 			}

--- a/js/editor.js
+++ b/js/editor.js
@@ -553,6 +553,7 @@ function Map(sizex, sizey) {
 
 	this.mirrorPart = function(mapObject, x1, x2, y1, y2, type, reverse) {
 		var uncompleteRooms = {};
+		var copiedRooms = {};
 		
 		// find uncomplete rooms (going through the mirror part)
 		map.forEachCell(x1, x2, y1, y2, function(col, row) {
@@ -606,14 +607,24 @@ function Map(sizex, sizey) {
 				// see above
 				return;
 			} else {
-				// the room is overwritten
-				// delete mapObject.tileIds[type == "horizontal" ? tileIdHor : tileIdVert];
-				// newId = true;
+				if (tileIdMir) {
+					// room is mirrored, create a new id
+					var newId = copiedRooms[tileIdMir];
+					if (!newId) {
+						// as most of it happens nearly instantly, add a custom number to it
+						// otherwise the room ids aren´t unique anymore
+						newId = copiedRooms[tileIdMir] = new Date().getTime() + row * col;
+						mapObject.tileIds.push(newId);
+					}
+					var dataId = mapObject.tileIds.indexOf(newId);
+					mirrorPart["data-id"] = dataId;
+				}
 			}
 			
 			if (posx && posy) {
-				newPosx = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posx - 1;
-				newPosy = tiles[mapObject.tiles[mirrorPart['tile']]].sizey - posy - 1;
+				// parse it to string, otherwise the import fails
+				newPosx = (tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posx - 1).toString();
+				newPosy = (tiles[mapObject.tiles[mirrorPart['tile']]].sizey - posy - 1).toString();
 			}
 			
 			if (type == "horizontal") {

--- a/js/editor.js
+++ b/js/editor.js
@@ -507,4 +507,48 @@ function Map(sizex, sizey) {
 	this.hideElement = function(id) {
 		document.getElementById(id).style.display = "none";	
 	}
+
+	/**
+	 * Mirrors a part of the map to get a better
+	 * @param mirrorType determines how the map should be mirrored
+	 *					 It's the sum of the cellvalues in the option menu
+	 * 		---------
+	 * 		| 1 | 2 | 
+	 * 		---------
+	 * 		| 3 | 4 |
+	 *		---------
+	 */
+	this.mirrorMap = function(mirrorType) {
+		var mapObject = map.mapToJson();
+		switch(mirrorType) {
+			case 1:
+				// mirror 1 to 2
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length / 2), "vertical");
+				// mirror 1 & 2 to 3 & 4
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal");
+				break;
+			case 3: // 1 + 2
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal");
+				break;
+			case 4: // 1 + 3
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length), "vertical");
+				break;
+		}
+
+		var str = JSON.stringify(mapObject);
+		var base64 = btoa(str);
+		map.import(base64);
+	}
+
+	this.mirrorPart = function(mapObject, x1, x2, y1, y2, type) {
+		for (var i = y1; i < y2; i++){
+			for (var j = x1; j < x2; j++){
+				if (type == "horizontal") {
+					mapObject.map[mapObject.map.length - 1 - i][j] = mapObject.map[i][j];
+				} else {
+					mapObject.map[i][mapObject.map[0].length - 1 - j] = mapObject.map[i][j];
+				}
+			}
+		}
+	}
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -561,7 +561,7 @@ function Map(sizex, sizey) {
 		// find uncomplete rooms (going through the mirror part)
 		map.forEachCell(x1, x2, y1, y2, function(col, row) {
 			var cell = mapObject.map[row][col];
-			var tile = mapObject.tiles[cell["tile"]];
+			var tile = mapObject.tiles[cell["tile"]] || "";
 			var ptile = tile.search(playerSearch);
 			
 			if (ptile != -1) {
@@ -608,7 +608,7 @@ function Map(sizex, sizey) {
 			var tileIdHor = mapObject.tileIds[mapObject.map[newRow][newHCol]["data-id"]];
 			var tileIdVert = mapObject.tileIds[mapObject.map[newVRow][newCol]["data-id"]];
 			var tileIdMir = mapObject.tileIds[mirrorPart["data-id"]];
-			var tileName = mapObject.tiles[mirrorPart['tile']];
+			var tileName = mapObject.tiles[mirrorPart['tile']] || "";
 			
 			if (type == "horizontal" && tileIdHor && tileIdHor in uncompleteRooms) {
 				// an uncomplete room should not get mirrored, we keep the tiles

--- a/js/editor.js
+++ b/js/editor.js
@@ -413,7 +413,7 @@ function Map(sizex, sizey) {
 	this.mapToJson = function(author){
 		var table = document.getElementById("map");
 		var mapData = {
-			version: "1.0",
+			version: "1.1",
 			author: author || "",
 			border: map.borderSize,
 			tiles: [],

--- a/js/editor.js
+++ b/js/editor.js
@@ -542,7 +542,7 @@ function Map(sizex, sizey) {
 	}
 
 	this.mirrorPart = function(mapObject, x1, x2, y1, y2, type, reverse) {
-		var obsoleteRooms = {};
+		var uncompleteRooms = {};
 		
 		// find uncomplete rooms (going through the mirror part)
 		map.forEachCell(x1, x2, y1, y2, function(col, row) {
@@ -551,12 +551,12 @@ function Map(sizex, sizey) {
 			if (!tileId) {
 				return;
 			}
-			var room = obsoleteRooms[tileId];
+			var room = uncompleteRooms[tileId];
 			if (!room) {
 				// it's not in the list
 				var sizex = tiles[mapObject.tiles[cell['tile']]].sizex;
 				var sizey = tiles[mapObject.tiles[cell['tile']]].sizey;	
-				obsoleteRooms[tileId] = {
+				uncompleteRooms[tileId] = {
 					"size": sizex * sizey,
 					"count": 1
 				};
@@ -564,7 +564,7 @@ function Map(sizex, sizey) {
 				room.count++;
 				if (room.count == room.size) {
 					// the room is complete
-					delete obsoleteRooms[tileId];
+					delete uncompleteRooms[tileId];
 				}
 			}
 		});
@@ -584,13 +584,13 @@ function Map(sizex, sizey) {
 			var tileIdMir = mapObject.tileIds[mirrorPart["data-id"]];
 			var newId = false;
 			
-			if (type == "horizontal" && tileIdHor && tileIdHor in obsoleteRooms) {
+			if (type == "horizontal" && tileIdHor && tileIdHor in uncompleteRooms) {
 				// an uncomplete room should not get mirrored, we keep the tiles
 				return;
-			} else if (type == "vertical" && tileIdVert && tileIdVert in obsoleteRooms){
+			} else if (type == "vertical" && tileIdVert && tileIdVert in uncompleteRooms){
 				// the same as above in vertical mirror
 				return;
-			} else if (tileIdMir && tileIdMir in obsoleteRooms) {
+			} else if (tileIdMir && tileIdMir in uncompleteRooms) {
 				// see above
 				return;
 			} else {

--- a/js/editor.js
+++ b/js/editor.js
@@ -536,6 +536,8 @@ function Map(sizex, sizey) {
 				break;
 		}
 
+		console.log(mapObject);
+		
 		var str = JSON.stringify(mapObject);
 		var base64 = btoa(str);
 		map.import(base64);
@@ -545,9 +547,25 @@ function Map(sizex, sizey) {
 		for (var i = y1; i < y2; i++){
 			for (var j = x1; j < x2; j++){
 				if (type == "horizontal") {
-					mapObject.map[mapObject.map.length - 1 - i][reverse ? (x2 - 1 - j) : j] = mapObject.map[i][j];
+					// clone the mapobject cell
+					var mirrorPart = JSON.parse(JSON.stringify(mapObject.map[i][j]));
+					// fix tileposition
+					var posy = mirrorPart['data-pos-y'];
+					if (posy) {
+						posy = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posy - 1;
+						mirrorPart['data-pos-y'] = posy;
+					}
+					mapObject.map[mapObject.map.length - 1 - i][reverse ? (x2 - 1 - j) : j] = mirrorPart;
 				} else {
-					mapObject.map[reverse ? (y2 - 1 - i) : i][mapObject.map[0].length - 1 - j] = mapObject.map[i][j];
+					// clone the mapobject cell
+					var mirrorPart = JSON.parse(JSON.stringify(mapObject.map[i][j]));
+					// fix tileposition
+					var posx = mirrorPart['data-pos-x'];
+					if (posx) {
+						posx = tiles[mapObject.tiles[mirrorPart['tile']]].sizex - posx - 1;
+						mirrorPart['data-pos-x'] = posx;
+					}
+					mapObject.map[reverse ? (y2 - 1 - i) : i][mapObject.map[0].length - 1 - j] = mirrorPart;
 				}
 			}
 		}

--- a/js/editor.js
+++ b/js/editor.js
@@ -346,6 +346,8 @@ function Map(sizex, sizey) {
 	}
 
 	this.setRoom = function() {
+		// helper for selenium
+		// console.log("<tr>\n\t<td>click</td>\n\t<td>id=" + this.id + "</td>\n\t<td></td>\n</tr>");
 		map.insertTile(this, false, false);
 	}
 
@@ -504,6 +506,8 @@ function Map(sizex, sizey) {
 	}
 
 	this.setCurrentTile = function(roomTile) {
+		// helper for selenium
+		// console.log("<tr>\n\t<td>click</td>\n\t<td>id=" + roomTile + "</td>\n\t<td></td>\n</tr>");
 		map.currentTile = roomTile;
 	}
 	

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,6 +1,7 @@
 window.onload = function(){
 	terrain = new Map();
 	terrain.getQueryOptions();
+	initOptions();
 	terrain.preloadTiles(function(){
 		terrain.generateTileCss();
 		terrain.init();
@@ -518,20 +519,20 @@ function Map(sizex, sizey) {
 	 * 		| 3 | 4 |
 	 *		---------
 	 */
-	this.mirrorMap = function(mirrorType) {
+	this.mirrorMap = function(mirrorType, reverse) {
 		var mapObject = map.mapToJson();
 		switch(mirrorType) {
-			case 1:
+			case 'first':
 				// mirror 1 to 2
-				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length / 2), "vertical");
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length / 2), "vertical", reverse);
 				// mirror 1 & 2 to 3 & 4
-				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal");
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal", reverse);
 				break;
-			case 3: // 1 + 2
-				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal");
+			case 'second': // 1 + 2
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length), 0, parseInt(mapObject.map.length / 2), "horizontal", reverse);
 				break;
-			case 4: // 1 + 3
-				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length), "vertical");
+			case 'third': // 1 + 3
+				map.mirrorPart(mapObject, 0, parseInt(mapObject.map[0].length / 2), 0, parseInt(mapObject.map.length), "vertical", reverse);
 				break;
 		}
 
@@ -540,13 +541,13 @@ function Map(sizex, sizey) {
 		map.import(base64);
 	}
 
-	this.mirrorPart = function(mapObject, x1, x2, y1, y2, type) {
+	this.mirrorPart = function(mapObject, x1, x2, y1, y2, type, reverse) {
 		for (var i = y1; i < y2; i++){
 			for (var j = x1; j < x2; j++){
 				if (type == "horizontal") {
-					mapObject.map[mapObject.map.length - 1 - i][j] = mapObject.map[i][j];
+					mapObject.map[mapObject.map.length - 1 - i][reverse ? (x2 - 1 - j) : j] = mapObject.map[i][j];
 				} else {
-					mapObject.map[i][mapObject.map[0].length - 1 - j] = mapObject.map[i][j];
+					mapObject.map[reverse ? (y2 - 1 - i) : i][mapObject.map[0].length - 1 - j] = mapObject.map[i][j];
 				}
 			}
 		}

--- a/js/options.js
+++ b/js/options.js
@@ -55,16 +55,12 @@ function mirrorPreview(type) {
 		case 'second':
 			first.setAttribute("class", "active");
 			second.setAttribute("class", "active");
+			third.innerHTML = '1';
+			fourth.innerHTML = '2';
 			if (reverse.checked) {
-				third.innerHTML = '2';
-				third.setAttribute("class", "mirrorBoth");
-				fourth.innerHTML = '1';
-				fourth.setAttribute("class", "mirrorBoth");
+				third.parentNode.setAttribute("class", "mirrorBoth");
 			} else {
-				third.innerHTML = '1';
-				third.setAttribute("class", "mirrorVertical");
-				fourth.innerHTML = '2';
-				fourth.setAttribute("class", "mirrorVertical");
+				third.parentNode.setAttribute("class", "mirrorVertical");
 			}
 			break;
 		case 'third':
@@ -103,6 +99,8 @@ function resetMirror() {
 	third.removeAttribute("class");
 	fourth.innerHTML = '4';
 	fourth.removeAttribute("class");
+	
+	third.parentNode.removeAttribute("class");
 }
 
 function newMap(sizex, sizey) {

--- a/js/options.js
+++ b/js/options.js
@@ -1,3 +1,107 @@
+function initOptions() {
+	var first = document.getElementById('first');
+	var second = document.getElementById('second');
+	var third = document.getElementById('third');
+	var fourth = document.getElementById('fourth');
+	var reverse = document.getElementById('reverse');
+
+	reverse.onchange = resetPreview;
+
+	first.onmouseover = mirrorTable;
+	second.onmouseover = mirrorTable;
+	third.onmouseover = mirrorTable;
+
+	first.onmouseout = resetPreview;
+	second.onmouseout = resetPreview;
+	third.onmouseout = resetPreview;
+
+	first.onclick = setActive;
+	second.onclick = setActive;
+	third.onclick = setActive;
+
+	active = "";
+}
+
+function mirrorMap() {
+	terrain.mirrorMap(active, !reverse.disabled ? reverse.checked : false);
+	toggleOptions(false);
+}
+
+function setActive() {
+	active = this.id;
+}
+
+function mirrorTable() {
+	var type = this.id;
+	resetMirror();
+	mirrorPreview(type);
+}
+
+function mirrorPreview(type) {
+	switch(type) {
+		case 'first':
+			first.setAttribute("class", "active");
+			second.innerHTML = '1';
+			second.setAttribute("class", "mirrorHorizontal");
+			third.innerHTML = '1';
+			third.setAttribute("class", "mirrorVertical");
+			fourth.innerHTML = '1';
+			fourth.setAttribute("class", "mirrorBoth");
+			reverse.disabled = "disabled";
+			break;
+		case 'second':
+			first.setAttribute("class", "active");
+			second.setAttribute("class", "active");
+			if (reverse.checked) {
+				third.innerHTML = '2';
+				third.setAttribute("class", "mirrorBoth");
+				fourth.innerHTML = '1';
+				fourth.setAttribute("class", "mirrorBoth");
+			} else {
+				third.innerHTML = '1';
+				third.setAttribute("class", "mirrorVertical");
+				fourth.innerHTML = '2';
+				fourth.setAttribute("class", "mirrorVertical");
+			}
+			break;
+		case 'third':
+			first.setAttribute("class", "active");
+			third.setAttribute("class", "active");
+			if (reverse.checked) {
+				second.innerHTML = '3';
+				second.setAttribute("class", "mirrorBoth");
+				fourth.innerHTML = '1';
+				fourth.setAttribute("class", "mirrorBoth");
+			} else {
+				second.innerHTML = '1';
+				second.setAttribute("class", "mirrorHorizontal");
+				fourth.innerHTML = '3';
+				fourth.setAttribute("class", "mirrorHorizontal");
+			}
+			break;
+	}
+}
+
+function resetPreview(){
+	resetMirror();
+	
+	if (active) {
+		mirrorPreview(active);
+	}
+}
+
+function resetMirror() {
+	reverse.disabled = "";
+
+	first.removeAttribute("class");
+	second.innerHTML = '2';
+	second.removeAttribute("class");
+	third.innerHTML = '3';
+	third.removeAttribute("class");
+	fourth.innerHTML = '4';
+	fourth.removeAttribute("class");
+}
+
 function newMap(sizex, sizey) {
 	sizex = parseInt(document.getElementById("width").value);
 	sizey = parseInt(document.getElementById("height").value);

--- a/js/options.js
+++ b/js/options.js
@@ -34,7 +34,7 @@ function mirrorMap() {
 }
 
 function setActive() {
-	active = this.id == "fourth" ? "third" : this.id;
+	active = this.id;
 }
 
 function mirrorTable() {
@@ -66,8 +66,8 @@ function mirrorPreview(type) {
 				third.parentNode.setAttribute("class", "mirrorVertical");
 			}
 			break;
-		default:
 		case 'third':
+		default:
 			first.setAttribute("class", "active");
 			third.setAttribute("class", "active");
 			if (reverse.checked) {

--- a/js/options.js
+++ b/js/options.js
@@ -10,14 +10,17 @@ function initOptions() {
 	first.onmouseover = mirrorTable;
 	second.onmouseover = mirrorTable;
 	third.onmouseover = mirrorTable;
+	fourth.onmouseover = mirrorTable;
 
 	first.onmouseout = resetPreview;
 	second.onmouseout = resetPreview;
 	third.onmouseout = resetPreview;
+	fourth.onmouseout = resetPreview;
 
 	first.onclick = setActive;
 	second.onclick = setActive;
 	third.onclick = setActive;
+	fourth.onclick = setActive;
 
 	active = "";
 }
@@ -31,7 +34,7 @@ function mirrorMap() {
 }
 
 function setActive() {
-	active = this.id;
+	active = this.id == "fourth" ? "third" : this.id;
 }
 
 function mirrorTable() {
@@ -63,6 +66,7 @@ function mirrorPreview(type) {
 				third.parentNode.setAttribute("class", "mirrorVertical");
 			}
 			break;
+		default:
 		case 'third':
 			first.setAttribute("class", "active");
 			third.setAttribute("class", "active");

--- a/js/options.js
+++ b/js/options.js
@@ -6,6 +6,9 @@
 	var reverse = document.getElementById('reverse');
 	var extend = document.getElementById('extend');
 
+	reverse.checked = "";
+	extend.checked = "";
+	
 	reverse.onchange = resetPreview;
 
 	first.onmouseover = mirrorTable;

--- a/js/options.js
+++ b/js/options.js
@@ -23,8 +23,11 @@ function initOptions() {
 }
 
 function mirrorMap() {
-	terrain.mirrorMap(active, !reverse.disabled ? reverse.checked : false);
-	toggleOptions(false);
+	var ok = confirm("This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?");
+	if (ok) {
+		terrain.mirrorMap(active, !reverse.disabled ? reverse.checked : false);
+		toggleOptions(false);
+	}
 }
 
 function setActive() {

--- a/js/options.js
+++ b/js/options.js
@@ -33,7 +33,7 @@ function mirrorMap() {
 	}
 	var ok = confirm("This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?");
 	// we extend the map
-	if (!extend.disabled) {
+	if (!extend.disabled && extend.checked) {
 		switch(active) {
 			case 'first':
 				terrain.mapsizex *= 2;

--- a/js/options.js
+++ b/js/options.js
@@ -1,9 +1,10 @@
-function initOptions() {
+ï»¿function initOptions() {
 	var first = document.getElementById('first');
 	var second = document.getElementById('second');
 	var third = document.getElementById('third');
 	var fourth = document.getElementById('fourth');
 	var reverse = document.getElementById('reverse');
+	var extend = document.getElementById('extend');
 
 	reverse.onchange = resetPreview;
 
@@ -26,7 +27,27 @@ function initOptions() {
 }
 
 function mirrorMap() {
+	if (!active) {
+		alert("Please choose a mirror type!");
+		return;
+	}
 	var ok = confirm("This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?");
+	// we extend the map
+	if (!extend.disabled) {
+		switch(active) {
+			case 'first':
+				terrain.mapsizex *= 2;
+				terrain.mapsizey *= 2;
+				break;
+			case 'second':
+				terrain.mapsizey *= 2;
+				break;
+			case 'third':
+			default:
+				terrain.mapsizex *= 2;
+				break;
+		}
+	}
 	if (ok) {
 		terrain.mirrorMap(active, !reverse.disabled ? reverse.checked : false);
 		toggleOptions(false);
@@ -54,6 +75,9 @@ function mirrorPreview(type) {
 			fourth.innerHTML = '1';
 			fourth.setAttribute("class", "mirrorBoth");
 			reverse.disabled = "disabled";
+			if (terrain.mapsizex * 2 > terrain.maxsize || terrain.mapsizey * 2 > terrain.maxsize) {
+				extend.disabled = "disabled";
+			}
 			break;
 		case 'second':
 			first.setAttribute("class", "active");
@@ -64,6 +88,9 @@ function mirrorPreview(type) {
 				third.parentNode.setAttribute("class", "mirrorBoth");
 			} else {
 				third.parentNode.setAttribute("class", "mirrorVertical");
+			}
+			if (terrain.mapsizey * 2 > terrain.maxsize) {
+				extend.disabled = "disabled";
 			}
 			break;
 		case 'third':
@@ -81,6 +108,9 @@ function mirrorPreview(type) {
 				fourth.innerHTML = '3';
 				fourth.setAttribute("class", "mirrorHorizontal");
 			}
+			if (terrain.mapsizex * 2 > terrain.maxsize) {
+				extend.disabled = "disabled";
+			}
 			break;
 	}
 }
@@ -95,6 +125,7 @@ function resetPreview(){
 
 function resetMirror() {
 	reverse.disabled = "";
+	extend.disabled = "";
 
 	first.removeAttribute("class");
 	second.innerHTML = '2';
@@ -111,11 +142,11 @@ function newMap(sizex, sizey) {
 	sizex = parseInt(document.getElementById("width").value);
 	sizey = parseInt(document.getElementById("height").value);
 	if (!isNaN(sizex) && !isNaN(sizey)) {
-		if (sizex >= 5 && sizey >= 5 && sizex <= 130 && sizey <= 130) {
+		if (sizex >= terrain.minsize && sizey >= terrain.minsize && sizex <= terrain.maxsize && sizey <= terrain.maxsize) {
 			terrain = new Map(sizex, sizey);
 			terrain.init();
 		} else {
-			alert("A valid map has to at least 5 by 5 and 130 by 130 max");
+			alert("A valid map has to at least " + terrain.minsize + " by " + terrain.minsize + " and " + terrain.maxsize + " by " + terrain.maxsize + " max");
 			return;
 		}
 	} else {
@@ -168,7 +199,7 @@ function importMap() {
 			return;
 		}
 	} else {
-		alert('Your browser isn´t supported!');
+		alert('Your browser isn`t supported!');
 		return;
 	}
 	toggleOptions(false);

--- a/tests/general/new map 20 20.html
+++ b/tests/general/new map 20 20.html
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>new map</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">new map</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=width</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=height</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;submit&quot;]</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/general/testmap1.html
+++ b/tests/general/testmap1.html
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Draw test map</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Draw test map</td></tr>
+</thead><tbody>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=core_p1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=core_p1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=claimed_earth_p1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=impenetrable</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=goldshrine</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=archiveshrine</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=siegeshrine</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=manashrine</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=gold</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=brimstone</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=lava</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sacred_earth</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=water</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_4</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/general/testmap1.html
+++ b/tests/general/testmap1.html
@@ -293,7 +293,47 @@
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=col_8_4</td>
+	<td>id=dirt</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_15</td>
 	<td></td>
 </tr>
 </tbody></table>

--- a/tests/general/testmap2.html
+++ b/tests/general/testmap2.html
@@ -1,0 +1,3351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Draw test map</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Draw test map</td></tr>
+</thead><tbody>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=core_p1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=impenetrable</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_1_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_2_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_13_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_14_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_21_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_21_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_22_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_2</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_3</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_5</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_6</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_8</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_9</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_10</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_11</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=lava</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_3_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_4_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_5_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=gold</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_6_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_7_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_9_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_10_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_11_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_12_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_15_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_16_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_17_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_18_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_19_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_20_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_21_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_21_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_21_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_22_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_22_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_22_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_23_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_23_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_24_13</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_23_12</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_36_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=brimstone</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_14</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_34_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_35_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=water</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_15</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_36</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_35</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=permafrost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_16</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_30_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_17</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_29_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_18</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_19</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_20</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_21</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_22</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_23</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_24</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_26</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_30</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_31</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_26_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_28_33</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_27_34</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=archiveshrine</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_25_7</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=gateway</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_37_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_25</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=core_p1</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_32</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=dirt</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_28</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_8_29</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_31_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_32_27</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=col_33_27</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/index.html
+++ b/tests/simple mirror/index.html
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="content-type" />
+  <title>Test Suite</title>
+</head>
+<body>
+<table id="suiteTable" cellpadding="1" cellspacing="1" border="1" class="selenium"><tbody>
+<tr><td><b>Test Suite</b></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 1.html">mirror 1</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 1 extend.html">mirror 1 extend</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 2.html">mirror 2</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 2 extend.html">mirror 2 extend</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 2 reverse.html">mirror 2 reverse</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 2 reverse extend.html">mirror 2 reverse extend</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 3.html">mirror 3</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 3 extend.html">mirror 3 extend</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 3 reverse.html">mirror 3 reverse</a></td></tr>
+<tr><td><a href="../general/new map 20 20.html">new map 20 20</a></td></tr>
+<tr><td><a href="../general/testmap1.html">testmap1</a></td></tr>
+<tr><td><a href="mirror 3 reverse extend.html">mirror 3 reverse extend</a></td></tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 1 extend.html
+++ b/tests/simple mirror/mirror 1 extend.html
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=first</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>20</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 1.html
+++ b/tests/simple mirror/mirror 1.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=first</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>8</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 2 extend.html
+++ b/tests/simple mirror/mirror 2 extend.html
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=second</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>10</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 2 reverse extend.html
+++ b/tests/simple mirror/mirror 2 reverse extend.html
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=second</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>10</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 2 reverse.html
+++ b/tests/simple mirror/mirror 2 reverse.html
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=second</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>7</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 2.html
+++ b/tests/simple mirror/mirror 2.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 2</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 2</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=second</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>7</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 3 extend.html
+++ b/tests/simple mirror/mirror 3 extend.html
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=third</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>10</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 3 reverse extend.html
+++ b/tests/simple mirror/mirror 3 reverse extend.html
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=third</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=extend</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>40</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>10</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 3 reverse.html
+++ b/tests/simple mirror/mirror 3 reverse.html
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 1 extend</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 1 extend</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=third</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=reverse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>7</td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/tests/simple mirror/mirror 3.html
+++ b/tests/simple mirror/mirror 3.html
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://change-this-to-the-site-you-are-testing/" />
+<title>Mirror 2</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Mirror 2</td></tr>
+</thead><tbody>
+<tr>
+	<td>click</td>
+	<td>id=optionButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=third</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#mirrorButton &gt; button</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertConfirmation</td>
+	<td>This recalculates the whole map and may remove some of your changes. Are you sure you want to continue?</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotVisible</td>
+	<td>id=options</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizex</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>window.terrain.mapsizey</td>
+	<td>20</td>
+</tr>
+<tr>
+	<td>assertEval</td>
+	<td>Object.keys(window.terrain.tiles).length</td>
+	<td>7</td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
This should definitely help to build maps more easily. So you only have to build a half or a quarter of the map and then you are able to complete the map in one go.

The gui should look more like this:

|  |  |
| --- | --- |
| 1 | 2 |
| 3 | 4 |

So you could choose 1 for a 4 player map and it gets mirrored to 2, 3 and 4
Or you choose 1 + 2 for a line and it gets mirrored to 3 and 4
or 1 + 3 and it gets mirrored to 2 and 4.
- [x] initial implementation (using the import/export feature)
- [x] Gui in options (maybe with some cool css-stuff like `transform: scale(-1, -1);`)
- [x] Change position of tiles on bigger rooms
- [x] Generate a new id for bigger rooms if mirrored
- [x] Mirror bigger rooms in the middle line correct (not at all ;))
- [x] Reverse mirroring: 1 and 3 gets mirrored to 2 (3) and 4 (1) instead of  2 (1) and 4 (3).
- [x] warning messages as needed (map will be overwritten and so on...)
- [x] Extend map option (use the whole map to mirror)
- [x] ~~Check for obsolete rooms (that may be overwritten during the process, see map.tiles)~~ Isn't necessary, because the importer is already smart enough and doesn't import them
- [x] Automaticly change player tiles (so they can be placed before and perfectly fit after mirroring)

This can be tested via https://rawgit.com/ufdada/wfto-mapeditor/map-mirror/index.html
