### PR TITLE
open readme in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 </div>
 <div id="toolBox">
 	<input type="button" id="optionButton" value="Options" onclick="toggleOptions(true)" />
-	<button onclick="window.location.href='https://github.com/ufdada/wfto-mapeditor/blob/gh-pages/README.md'">?</button>
+	<button onclick="window.open('https://github.com/ufdada/wfto-mapeditor/blob/gh-pages/README.md', '_blank')">?</button>
 	<button id="undo" onclick="terrain.undo()"><img src="./img/gui/undo.png" alt="Undo" title="Undo"/></button> <button id="redo" onclick="terrain.redo()"><img src="./img/gui/redo.png" alt="Redo" title="Redo"/></button>
 	<!-- here are the tile buttons -->
 	<div id="info">


### PR DESCRIPTION
The readme link should open it in a new tab / window instead of overwriting the current one, so the current map shouldn't be lost

Fixes #27 
