### PR TITLE
Export wfto map

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
         "window",
         "module",
         "terrain",
+        "tileTable",
         "JSON",
         "tiles",
         "dataStorage",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,9 @@
 		<label for="versioning">Versioning: </label><input title="Adds a version number to the name, starting with 001" type="checkbox" onchange="setVersioning(this)" id="versioning" /><br />
 		<p id="versionInfo">Current version: <span id="mapVersion"></span></p>
 		<label for="mapName">Mapname: </label><input type="text" id="mapName" value="Map"/><br />
-		<button id="export" onclick="exportMap()">Export as File</button><br />
+		<button id="export" onclick="exportMap('file')">Export as Binary-File</button>
+		<button id="exportGCsv" onclick="exportMap('gcsv')">Export as Google CSV</button>
+		<button id="exportWCsv" onclick="exportMap('wcsv')">Export as WFTO CSV (For importing into wfto)</button><br />
 		<label for="imageFormat">Imagetype: </label>
 		<select id="imageFormat">
 			<option value="jpeg" selected="selected">JPEG</option>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <script type="text/javascript" src="./js/tiles.js"></script>
 <script type="text/javascript" src="./js/editor.js"></script>
 <script type="text/javascript" src="./js/options.js"></script>
+<script type="text/javascript" src="./js/importHelper.js"></script>
 </head>
 <body>
 <div id="dropMessage"><p>Drop your Mapfile here</p></div>

--- a/js/editor.js
+++ b/js/editor.js
@@ -120,7 +120,7 @@ function Map(sizex, sizey) {
 			var option = map.options[item].option;
 			map[option] = map[option + "Default"];
 		}
-		terrain.generateTileCss();
+		map.generateTileCss();
 	};
 
 	this.generateTileCss = function() {
@@ -537,6 +537,39 @@ function Map(sizex, sizey) {
 				mapData.map.push(colData);
 			}
 			return mapData;
+		} else {
+			return null;
+		}
+	};
+	
+	this.mapToCsvJson = function(type){
+		var table = document.getElementById("map");
+		var csv = [];
+
+		if (table) {
+			for (var i = 0; i < map.mapsizey + map.borderSize * 2; i++) {
+
+				var tableRow = table.rows[i];
+				var colData = [];
+
+				for (var j = 0; j < map.mapsizex + map.borderSize * 2; j++) {
+					var tileName = '';
+					var tile = tableRow && tableRow.cells[j] || null;
+					// if the counter exeeds the count, we just add empty cells
+					// handy for the extend feature
+					if (tile) {
+						// make sure that non temporary tile is currently set
+						map.resetTile(tile);
+						
+						tileName = tileTable[ type == "gcsv" ? "getGoogleCsvValue" : "getWFTOCsvValue" ](tile.getAttribute("class"));
+					}
+
+					colData.push(tileName);
+				}
+
+				csv.push(colData);
+			}
+			return csv;
 		} else {
 			return null;
 		}
@@ -1016,80 +1049,15 @@ function Map(sizex, sizey) {
 				var cells = rows[i].split(",");
 
 				for (var j = bordersize; j < cells.length - bordersize; j++) {
-					var tileName = "";
 					var cell = {};
-					switch(cells[j].substring(0,2)) {
-						case 'go':
-							tileName = "gold";
-							break;
-						case 'di':
-							tileName = "dirt";
-							break;
-						case 'ch':
-							tileName = "chasm";
-							break;
-						case 'wa':
-							tileName = "water";
-							break;
-						case 'ga':
-							tileName = "gateway";
-							break;
-						case 'la':
-							tileName = "lava";
-							break;
-						case 'co':
-							tileName = "core_p1";
-							break;
-						case 'im':
-							tileName = "impenetrable";
-							break;
-						case 'br':
-							tileName = "brimstone";
-							break;
-						case 'se':
-							tileName = "sacred_earth";
-							break;
-						case 'nb':
-							tileName = "stone_bridge";
-							break;
-						case 'pf':
-							tileName = "permafrost";
-							break;
-						case 'sa':
-							tileName = "sand";
-							break;
-						case 'sh':
-							tileName = "archiveshrine";
-							break;
-						case 'sg':
-							tileName = "goldshrine";
-							break;
-						case 'ss':
-							tileName = "siegeshrine";
-							break;
-						case 'sd':
-							tileName = "defencepartshrine";
-							break;
-						case 'sm':
-							tileName = "manashrine";
-							break;
-						case 'sp':
-							tileName = "perceptionshrine";
-							break;
-						case '':
-							tileName = "earth";
-							break;
-						default:
-							console.error("Tile " + cells[j] + " could not be converted!");
-							tileName = "earth";
-					}
-
+					var tileName = tileTable.getEditorTilename(cells[j].substring(0,2));
 					var tileConfig = tiles[tileName];
+					
 					if (tileConfig && tileConfig.sizex * tileConfig.sizey > 1) {
 						calcRooms.push([i - bordersize, j - bordersize]);
 					}
 
-					var tileTypeId = terrain.getMapTileId(mapData, tileName);
+					var tileTypeId = map.getMapTileId(mapData, tileName);
 					cell["tile"] = tileTypeId;
 					rowData.push(cell);
 				}
@@ -1130,8 +1098,8 @@ function Map(sizex, sizey) {
 					}
 				}
 			}
-			terrain.resetRedoHistory();
-			terrain.importData(JSON.stringify(mapData));
+			map.resetRedoHistory();
+			map.importData(JSON.stringify(mapData));
 		} else {
 			alert("Please select a valid map file");
 			return;

--- a/js/importHelper.js
+++ b/js/importHelper.js
@@ -1,5 +1,5 @@
-var tileTable = {
-	defaultValue: 'earth',
+tileTable = {
+	defaultTile: 'earth',
 	map: {
 		'gold': [
 			'go',
@@ -8,6 +8,10 @@ var tileTable = {
 		'dirt': [
 			'di',
 			'8'
+		],
+		'earth': [
+			'',
+			'2'
 		],
 		'chasm': [
 			'ch',
@@ -29,6 +33,18 @@ var tileTable = {
 			'co',
 			'79'
 		],
+		'core_p2': [
+			'co',
+			'79'
+		],
+		'core_p3': [
+			'co',
+			'79'
+		],
+		'core_p4': [
+			'co',
+			'79'
+		],
 		'impenetrable': [
 			'im',
 			'1'
@@ -46,9 +62,10 @@ var tileTable = {
 			'14'
 		],
 		'wood_bridge': [
-			'wb',
-			''
+			'nb',
+			'13'
 		],
+		// TODO Should be natural_bridge, needs tile!
 		'natural_bridge': [
 			'nb',
 			'13'
@@ -84,15 +101,78 @@ var tileTable = {
 		'perceptionshrine': [
 			'sp',
 			'122'
+		],
+		// Additional tiles beyond the google csv ones
+		'claimed_earth_empire': [
+			'cee',
+			'10'
+		],
+		'claimed_floor_empire': [
+			'cfe',
+			'9'
+		],
+		'claimed_earth_p1': [
+			'cep',
+			'29'
+		],
+		'claimed_floor_p1': [
+			'cfp',
+			'28'
+		],
+		'claimed_earth_p2': [
+			'cep',
+			'29'
+		],
+		'claimed_floor_p2': [
+			'cfp',
+			'28'
+		],
+		'claimed_earth_p3': [
+			'cep',
+			'29'
+		],
+		'claimed_floor_p3': [
+			'cfp',
+			'28'
+		],
+		'claimed_earth_p4': [
+			'cep',
+			'29'
+		],
+		'claimed_floor_p4': [
+			'cfp',
+			'28'
+		],
+		'herogate': [
+			'hg',
+			'74'
+		],
+		// Beyond the terrain id table of marados
+		'inhibitorshrine': [
+			'si',
+			'134'
 		]
 	},
 	
 	getGoogleCsvValue: function ( value ) {
-		return this.map[ value ][0];
+		return this.getMapValue(value)[0];
 	},
 	
 	getWFTOCsvValue: function ( value ) {
-		return this.map[ value ][1];
+		return this.getMapValue(value)[1];
+	},
+	
+	getMapValue: function ( value ) {
+		return this.map[ value ] || this.map[ this.defaultTile ];
+	},
+	
+	getEditorTilename: function ( value ) {
+		var tilename = this.getKeyByValue( value );
+		if ( !tilename ) {
+			console.error("Tile " + value + " could not be converted! Falling back to default tile.");
+			tilename = this.defaultTile;
+		}
+		return tilename;
 	},
 	
 	getKeyByValue: function( value, map ) {
@@ -110,4 +190,4 @@ var tileTable = {
 			}
 		}
 	}
-}
+};

--- a/js/importHelper.js
+++ b/js/importHelper.js
@@ -1,0 +1,113 @@
+var tileTable = {
+	defaultValue: 'earth',
+	map: {
+		'gold': [
+			'go',
+			'0'
+		],
+		'dirt': [
+			'di',
+			'8'
+		],
+		'chasm': [
+			'ch',
+			'4'
+		],
+		'water': [
+			'wa',
+			'27'
+		],
+		'gateway': [
+			'ga',
+			'65'
+		],
+		'lava': [
+			'la',
+			'26'
+		],
+		'core_p1': [
+			'co',
+			'79'
+		],
+		'impenetrable': [
+			'im',
+			'1'
+		],
+		'brimstone': [
+			'br',
+			'6'
+		],
+		'sacred_earth': [
+			'se',
+			'5'
+		],
+		'stone_bridge': [
+			'nb',
+			'14'
+		],
+		'wood_bridge': [
+			'wb',
+			''
+		],
+		'natural_bridge': [
+			'nb',
+			'13'
+		],
+		'permafrost': [
+			'pf',
+			'3'
+		],
+		'sand': [
+			'sa',
+			'7'
+		],
+		'archiveshrine': [
+			'sh',
+			'128'
+		],
+		'goldshrine': [
+			'sg',
+			'71'
+		],
+		'siegeshrine': [
+			'ss',
+			'131'
+		],
+		'defencepartshrine': [
+			'sd',
+			'68'
+		],
+		'manashrine': [
+			'sm',
+			'125'
+		],
+		'perceptionshrine': [
+			'sp',
+			'122'
+		]
+	},
+	
+	getGoogleCsvValue: function ( value ) {
+		return this.map[ value ][0];
+	},
+	
+	getWFTOCsvValue: function ( value ) {
+		return this.map[ value ][1];
+	},
+	
+	getKeyByValue: function( value, map ) {
+		var obj = map || this.map;
+		for( var prop in  obj) {
+			if( obj.hasOwnProperty( prop ) ) {
+				if( obj[ prop ] === value ) {
+					return prop;
+				} else if (typeof obj[ prop ] == 'object') {
+					var item = this.getKeyByValue(value, obj[ prop ]);
+					if (item) {
+						return prop;
+					}
+				}
+			}
+		}
+	}
+}

--- a/js/options.js
+++ b/js/options.js
@@ -224,12 +224,19 @@ function newMap(sizex, sizey) {
 	toggleOptions(false);
 }
 
-function exportMap() {
-	// Maybe later
-	var author = ''; //document.getElementById("author").value;
-	// export as base64
-	var data = btoa(terrain.exportData(author));
-
+function exportMap( type ) {
+	var data = '';
+	var extension = ".wfto";
+	if (type == "file") {
+		// Maybe later
+		var author = ''; //document.getElementById("author").value;
+		// export as base64
+		data = btoa(terrain.exportData(author));
+	} else {
+		data = exportCsv( type );
+		extension = ".csv";
+	}
+	
 	var mapName = mapNameInput.value;
 	if (mapName.length < 1 || mapName.match(invalidLetterRegex)) {
 		alert("Invalid filename!");
@@ -239,7 +246,7 @@ function exportMap() {
 		mapName +=  "_" + terrain.version;
 		terrain.updateVersion();
 	}
-	mapName += ".wfto";
+	mapName += extension;
 
 	// Use the native blob constructor
 	var blob = new Blob([data], {type: "application/octet-stream"});
@@ -476,11 +483,20 @@ function importCsv() {
 	toggleOptions(false);
 }
 
-function setVersioning(element) {
+function setVersioning( element ) {
 	store.setItem(element.id, element.checked);
 	var mapVersion = document.getElementById("mapVersion");
 	mapVersion.innerHTML = terrain.version;
 
 	mapVersion.parentNode.style.display = element.checked ? "block" : "none";
 
+}
+
+function exportCsv( type ) {
+	var json = terrain.mapToCsvJson( type );
+	var content = '';
+	for (var i = 0; i < json.length; i++) {
+		content += json[i].join(',') + '\r\n';
+	}
+	return content;
 }


### PR DESCRIPTION
WFTO is now able to import special csv files to generate a map.

There are still some further tests left to do. The first ones from Marados were already promising.

_Current Workflow:_
- Put your csv file in the GameData folder
- Create a map in game (with correct dimension) `Create <mapname> <dimensionx> <dimenstiony> <factioncount>`
- And in game you use the command line `DataImport <filename>`
- Some things are needed to be tweaked (e.g. bridges)
- Players get populated this way:
  
  |  |  |
  | --- | --- |
  | P1 | Bottom left |
  | P2 | Bottom right |
  | P3 | Top left |
  | P4 | Top right |

_Things left to do:_
- Inhibitorshrine needs to be mapped in wfto (134).
