### PR TITLE
scale the gui with the window zoom level

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,12 +114,12 @@ td:hover {
 #mirrorMap td {
 	width: 15px;
 	padding: 5px;
-	transition: all 0.3s;
+	transition: transform 0.3s;
 	border: 1px solid black;
 }
 
 #mirrorMap tr {
-	transition: all 0.3s;
+	transition: transform 0.3s;
 }
 
 #mirrorMap td.active {

--- a/js/editor.js
+++ b/js/editor.js
@@ -1283,7 +1283,11 @@ function Map(sizex, sizey) {
 		styleHtml += '.tileButton { background-size: ' + parseInt(tileSize * 3/4) + 'px !important; width: ' + parseInt(tileSize * 3/4) + 'px !important; height: ' + parseInt(tileSize * 3/4) + 'px !important; border: ' + 1 / scale + 'px solid white; }\n';
 		styleHtml += '#map { padding-top: 10px; margin-left: '+parseInt(tileSize * map.buttonColumns)+'px; }\n';
 		styleHtml += '#buttons { width:' + parseInt(tileSize * 3/4 * map.buttonColumns) + 'px  !important }\n';
-		
+		styleHtml += '#options { padding: ' + ( 10 / scale ) + 'px; width: ' + ( 500 / scale ) + 'px; left: calc(50% - ' + ( 250 / scale ) + 'px) !important; top: ' + ( 100 / scale ) + 'px; font-size: ' + parseInt( 12 / scale ) + 'px }\n';
+		styleHtml += '#options input, #options button, #options select {font-size: ' + parseInt(12 / scale) + 'px !important;  padding: ' + parseInt(1 / scale)  + 'px ' + parseInt(6 / scale)  + 'px; }\n';
+		styleHtml += '#options #mirrorMap { border-spacing: ' + (1 / scale) + 'px !important; }\n';
+		styleHtml += '#options #mirrorMap td { padding: ' + parseInt(5 / scale) + 'px !important; width: ' + parseInt(15 / scale) + 'px; }\n';
+
 		style.innerHTML = styleHtml;
 		document.getElementsByTagName('head')[0].appendChild(style);
 	};

--- a/js/editor.js
+++ b/js/editor.js
@@ -190,11 +190,14 @@ function Map(sizex, sizey) {
 	};
 
 	this.createButtons = function() {
+		var tileSize = map.tileSizeDefault;
 		var toolBox = document.getElementById("toolBox");
 		toolBox.onmousemove = map.hideInfoBox;
+		toolBox.setAttribute("class", "toolBox" + tileSize);
 		var info = document.getElementById("info");
 		var buttons = document.createElement("div");
 		buttons.id = "buttons";
+		buttons.style.width = parseInt(tileSize * 3/4 * map.buttonColumns) + "px";
 
 		for (var item in tiles) {
 			var button = document.createElement("input");
@@ -206,6 +209,7 @@ function Map(sizex, sizey) {
 			button.type = "button";
 			button.setAttribute("class", item + " tileButton");
 			button.setAttribute("title", item);
+			button.setAttribute("style", "background-size: " + parseInt(tileSize * 3/4) + "px; width: " + parseInt(tileSize * 3/4) + "px; height: " + parseInt(tileSize * 3/4) + "px");
 			buttons.appendChild(button);
 		}
 		toolBox.insertBefore(buttons, info);
@@ -350,8 +354,8 @@ function Map(sizex, sizey) {
 
 	this.setRoomOnDrag = function(evt) {
 		var infoBox = document.getElementById("infoBox");
-		var left = evt.pageX + (20 / window.devicePixelRatio);
-		var top = evt.pageY + (20 / window.devicePixelRatio);
+		var left = (evt.pageX) * window.devicePixelRatio + 20;
+		var top = (evt.pageY) * window.devicePixelRatio + 20;
 
 		var height = infoBox.clientHeight;
 		var width = infoBox.clientWidth;
@@ -360,16 +364,16 @@ function Map(sizex, sizey) {
 		var pageOffsetX = window.pageXOffset;
 		var pageOffsetY = window.pageYOffset;
 
-		if (top + height > windowHeight + pageOffsetY - 10) {
+		if (top + height > (windowHeight + pageOffsetY) * window.devicePixelRatio - 10) {
 			// at the bottom edge
-			infoBox.style.top = top - height - (30 / window.devicePixelRatio) + "px";
+			infoBox.style.top = top - height - 30 + "px";
 		} else {
 			infoBox.style.top = top + "px";
 		}
 
-		if (left + width > windowWidth + pageOffsetX - 10) {
+		if (left + width > (windowWidth + pageOffsetX) * window.devicePixelRatio - 10) {
 			// at the right edge
-			infoBox.style.left = left - width - (30 / window.devicePixelRatio) + "px";
+			infoBox.style.left = left - width - 30 + "px";
 		} else {
 			infoBox.style.left = left + "px";
 		}
@@ -1265,6 +1269,26 @@ function Map(sizex, sizey) {
 	};
 
 	this.scaleGUI = function() {
+		var scale = window.devicePixelRatio || 1;
+		var tileSize = map.tileSizeDefault / scale;
+		var style = document.getElementById('toolBoxCss') || document.createElement('style');
+		style.id = 'toolBoxCss';
+		style.type = 'text/css';
+		var styleHtml = '#map { padding-top: 10px; margin-left: ' + (tileSize * map.buttonColumns) + 'px; !important }\n';
+		style.innerHTML = styleHtml;
+		document.getElementsByTagName('head')[0].appendChild(style);
+		
+		if (document.getElementById("options")) {
+			document.getElementById("options").style.zoom = 1 / window.devicePixelRatio;
+			document.getElementById("toolBox").style.zoom = 1 / window.devicePixelRatio;
+			// document.getElementById("resizeTable").style.zoom = 1 / window.devicePixelRatio;
+			document.getElementById("infoBox").style.zoom = 1 / window.devicePixelRatio;
+			//document.getElementById("#options").style.zoom = 1 / window.devicePixelRatio;
+			
+		}
+	};
+	
+	this.scaleGUIold = function() {
 		var style = document.getElementById('toolBoxCss') || document.createElement('style');
 		var toolBox = document.getElementById("toolBox");
 		var scale = window.devicePixelRatio || 1;
@@ -1275,19 +1299,20 @@ function Map(sizex, sizey) {
 		toolBox.setAttribute("class", "toolBox" + tileSize);
 		
 		var styleHtml = '';
-		styleHtml += '#resizeTable td { font-size: ' + parseInt(tileSize / 3) + 'px; }\n';
-		styleHtml += '#toolBox,  #toolBox input, #toolBox button { font-size: ' + parseInt(tileSize / 6) + 'px !important;  padding: ' + parseInt(1 / scale)  + 'px ' + parseInt(6 / scale)  + 'px; }\n';
-		styleHtml += '#toolBox button, #toolBox .optionButton { margin-bottom: ' + 10 / scale  + 'px; }\n';
-		styleHtml += '#toolBox img { width: ' + parseInt(tileSize / 4) + 'px !important; }\n';
-		styleHtml += '#toolBox { width: ' + parseInt(175 / scale) + 'px !important; }\n';
-		styleHtml += '.tileButton { background-size: ' + parseInt(tileSize * 3/4) + 'px !important; width: ' + parseInt(tileSize * 3/4) + 'px !important; height: ' + parseInt(tileSize * 3/4) + 'px !important; border: ' + 1 / scale + 'px solid white; }\n';
-		styleHtml += '#map { padding-top: 10px; margin-left: '+parseInt(tileSize * map.buttonColumns)+'px; }\n';
-		styleHtml += '#buttons { width:' + parseInt(tileSize * 3/4 * map.buttonColumns) + 'px  !important }\n';
-		styleHtml += '#options { padding: ' + ( 10 / scale ) + 'px; width: ' + ( 500 / scale ) + 'px; left: calc(50% - ' + ( 250 / scale ) + 'px) !important; top: ' + ( 100 / scale ) + 'px; font-size: ' + parseInt( 12 / scale ) + 'px }\n';
-		styleHtml += '#options input, #options button, #options select {font-size: ' + parseInt(12 / scale) + 'px !important;  padding: ' + parseInt(1 / scale)  + 'px ' + parseInt(6 / scale)  + 'px; }\n';
-		styleHtml += '#options #mirrorMap { border-spacing: ' + (1 / scale) + 'px !important; }\n';
-		styleHtml += '#options #mirrorMap td { padding: ' + parseInt(5 / scale) + 'px !important; width: ' + parseInt(15 / scale) + 'px; }\n';
-		styleHtml += '#infoBox { font-size: ' + parseInt(12 / scale) + 'px !important; border-radius: ' + parseInt(4 / scale) + 'px; padding: ' + parseInt(5 / scale) + 'px; margin-bottom: ' + parseInt(10 / scale) + 'px }\n';
+		styleHtml += '#resizeTable td { font-size: ' + ( tileSize / 3 ) + 'px; }\n';
+		styleHtml += '#toolBox,  #toolBox input, #toolBox button { font-size: ' + ( tileSize / 6 ) + 'px !important;  padding: ' + ( 1 / scale )  + 'px ' + ( 6 / scale )  + 'px; }\n';
+		styleHtml += '#toolBox button, #toolBox .optionButton { margin-bottom: ' + ( 10 / scale ) + 'px; }\n';
+		styleHtml += '#toolBox img { width: ' + ( tileSize / 4 ) + 'px !important; }\n';
+		styleHtml += '#toolBox { width: ' + ( 175 / scale ) + 'px !important; }\n';
+		styleHtml += '.tileButton { background-size: ' + ( tileSize * 3/4 ) + 'px !important; width: ' + ( tileSize * 3/4 ) + 'px !important; height: ' + ( tileSize * 3/4 ) + 'px !important; border: ' + ( 1 / scale ) + 'px solid white; }\n';
+		
+		styleHtml += '#buttons { width:' + ( tileSize * 3/4 * map.buttonColumns ) + 'px  !important }\n';
+		styleHtml += '#options { padding: ' + ( 10 / scale ) + 'px; width: ' + ( 500 / scale ) + 'px; left: calc(50% - ' + ( 250 / scale ) + 'px) !important; top: ' + ( 100 / scale ) + 'px; font-size: ' + ( 12 / scale ) + 'px }\n';
+		styleHtml += '#options input, #options button, #options select {font-size: ' + ( 12 / scale ) + 'px !important;  padding: ' + ( 1 / scale )  + 'px ' + ( 6 / scale )  + 'px; }\n';
+		styleHtml += '#options #mirrorMap { border-spacing: ' + ( 1 / scale ) + 'px !important; }\n';
+		styleHtml += '#options #mirrorMap td { padding: ' + ( 5 / scale ) + 'px !important; width: ' + ( 15 / scale ) + 'px; }\n';
+		styleHtml += '#options fieldset { margin: ' + ( 10 / scale ) + 'px; border-width: ' + ( 1 / scale ) + 'px; }\n';
+		styleHtml += '#infoBox { font-size: ' + ( 12 / scale ) + 'px !important; border-radius: ' + ( 4 / scale ) + 'px; padding: ' + ( 5 / scale ) + 'px; margin-bottom: ' + ( 10 / scale ) + 'px }\n';
 
 		style.innerHTML = styleHtml;
 		document.getElementsByTagName('head')[0].appendChild(style);

--- a/js/editor.js
+++ b/js/editor.js
@@ -350,8 +350,8 @@ function Map(sizex, sizey) {
 
 	this.setRoomOnDrag = function(evt) {
 		var infoBox = document.getElementById("infoBox");
-		var left = evt.pageX + 20;
-		var top = evt.pageY + 20;
+		var left = evt.pageX + (20 / window.devicePixelRatio);
+		var top = evt.pageY + (20 / window.devicePixelRatio);
 
 		var height = infoBox.clientHeight;
 		var width = infoBox.clientWidth;
@@ -362,14 +362,14 @@ function Map(sizex, sizey) {
 
 		if (top + height > windowHeight + pageOffsetY - 10) {
 			// at the bottom edge
-			infoBox.style.top = top - height - 30 + "px";
+			infoBox.style.top = top - height - (30 / window.devicePixelRatio) + "px";
 		} else {
 			infoBox.style.top = top + "px";
 		}
 
 		if (left + width > windowWidth + pageOffsetX - 10) {
 			// at the right edge
-			infoBox.style.left = left - width - 30 + "px";
+			infoBox.style.left = left - width - (30 / window.devicePixelRatio) + "px";
 		} else {
 			infoBox.style.left = left + "px";
 		}
@@ -1287,6 +1287,7 @@ function Map(sizex, sizey) {
 		styleHtml += '#options input, #options button, #options select {font-size: ' + parseInt(12 / scale) + 'px !important;  padding: ' + parseInt(1 / scale)  + 'px ' + parseInt(6 / scale)  + 'px; }\n';
 		styleHtml += '#options #mirrorMap { border-spacing: ' + (1 / scale) + 'px !important; }\n';
 		styleHtml += '#options #mirrorMap td { padding: ' + parseInt(5 / scale) + 'px !important; width: ' + parseInt(15 / scale) + 'px; }\n';
+		styleHtml += '#infoBox { font-size: ' + parseInt(12 / scale) + 'px !important; border-radius: ' + parseInt(4 / scale) + 'px; padding: ' + parseInt(5 / scale) + 'px; margin-bottom: ' + parseInt(10 / scale) + 'px }\n';
 
 		style.innerHTML = styleHtml;
 		document.getElementsByTagName('head')[0].appendChild(style);


### PR DESCRIPTION
A user should still be able to read/operate with the gui even on a extrem small or large zoom level (!= 100%). So the user can easily get an overview of the map while exporting it without having to restore the 100% zoom level.

Following things have to be done so it can work:
- [x] scale toolbar
- [x] scale options
- [x] scale tooltip(s)
