### PR TITLE
New implementation of mapzooming

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,11 @@ html, body {
 	font-size: 12px;
 }
 
+body {
+	padding-top: 30px;
+	padding-left: 180px;
+}
+
 a {
 	text-decoration: none;
 }
@@ -41,10 +46,6 @@ td:hover {
 #toolBox p {
 	color: #ccc;
 	text-shadow: 0px 0px 2px black;
-}
-
-#toolBox input, #toolBox button {
-	padding: 0;
 }
 
 #preload{

--- a/css/style.css
+++ b/css/style.css
@@ -212,3 +212,7 @@ button:disabled img {
 	right: 20px;
 	top: 20px;
 }
+
+#map {
+	transform-origin: top left;
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@
 </div>
 <div id="toolBox">
 	<input type="button" id="optionButton" value="Options" onclick="toggleOptions(true)" />
-	<button onclick="window.open('https://github.com/ufdada/wfto-mapeditor/blob/gh-pages/README.md', '_blank')">?</button><br />
+	<button onclick="window.open('https://github.com/ufdada/wfto-mapeditor/blob/gh-pages/README.md', '_blank')">?</button>
+	<button onclick="terrain.zoomMap(1.0)" title="Reset Zoom">100%</button><br />
 	<button id="undo" onclick="terrain.undo()"><img src="./img/gui/undo.png" alt="Undo" title="Undo"/></button> <button id="redo" onclick="terrain.redo()"><img src="./img/gui/redo.png" alt="Redo" title="Redo"/></button>
 	<!-- here are the tile buttons -->
 	<div id="info">

--- a/js/editor.js
+++ b/js/editor.js
@@ -1245,7 +1245,7 @@ function Map(sizex, sizey) {
 				mult *= 3;
 			}
 
-			zoomIndicator = -evt.detail || evt.wheelDeltaY;
+			var zoomIndicator = -evt.detail || evt.wheelDeltaY;
 
 			map.zoom += zoomIndicator > 0 ? mult : -mult;
 			map.zoom = Math.max(0.2, Math.min(map.zoom, 4.0));

--- a/js/editor.js
+++ b/js/editor.js
@@ -1259,6 +1259,5 @@ function Map(sizex, sizey) {
 		window.devicePixelRatio = 1;
 		var mapTable = document.getElementById("map");
 		mapTable.style.transform = "scale(" + zoom + ")";
-		mapTable.style.transformOrigin = "top left";
 	};
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -292,8 +292,9 @@ function Map(sizex, sizey) {
 		
 		map.zoomMap(map.zoom);
 		
-		document.addEventListener("mousewheel", map.mouseWheelListener, false);
-		document.addEventListener("DOMMouseScroll", map.mouseWheelListener, false);
+		window.addEventListener("keydown", map.keydownListener, false);
+		window.addEventListener("mousewheel", map.mouseWheelListener, false);
+		window.addEventListener("DOMMouseScroll", map.mouseWheelListener, false);
 	};
 
 	this.destroy = function() {
@@ -1240,23 +1241,36 @@ function Map(sizex, sizey) {
 	
 	this.mouseWheelListener = function(evt) {
 		if (evt.ctrlKey) {
-			var mult = 0.2;
-			if (evt.shiftKey) {
-				mult *= 3;
-			}
-
 			var zoomIndicator = -evt.detail || evt.wheelDeltaY;
-
-			map.zoom += zoomIndicator > 0 ? mult : -mult;
-			map.zoom = Math.max(0.2, Math.min(map.zoom, 4.0));
+			map.calculateZoom(zoomIndicator > 0, evt.shiftKey);
 
 			evt.preventDefault();
-			map.zoomMap(map.zoom);
 		}
 	};
 	
+	this.keydownListener = function(evt) {
+		if (evt.ctrlKey && evt.keyCode == 187 || evt.keyCode == 189) {
+			map.calculateZoom(evt.keyCode == 187, evt.shiftKey);
+
+			evt.preventDefault();
+		}
+	};
+	
+	this.calculateZoom = function(zoomIndicator, turbo) {
+		var level = 0.2;
+		if (turbo) {
+			level *= 2;
+		}
+
+		var zoom = map.zoom;
+		zoom += zoomIndicator ? level : -level;
+		zoom = Math.max(0.2, Math.min(zoom, 4.0));
+
+		map.zoomMap(zoom);
+	};
+	
 	this.zoomMap = function(zoom) {
-		window.devicePixelRatio = 1;
+		map.zoom = zoom;
 		var mapTable = document.getElementById("map");
 		mapTable.style.transform = "scale(" + zoom + ")";
 	};


### PR DESCRIPTION
Instead of working arround and zoom all other elements to be readable with may be faulty in some cases (input elements don't zoom very well), the new approach should just zoom the map alone and leave the rest as it is.
- [x] Prevent default behaviour (zoom all objects)
- [x] Only zoom the map (Test with Firefox, Chrome and IE 10+ / Edge)
- [x] Make the zoom faster with Shift (doesn't work in Chrome with zooming in...)
- [x] The same thing for <kbd>CTRL</kbd> + <kbd>+</kbd> and <kbd>CTRL</kbd> + <kbd>-</kbd>
- [ ] ~~Use the same zooming steps like in the browsers itself:~~ Way to complicated with too little benefits

``` javascript
  zoomLevel = 5;
  zoomLevelBefore = 10;
  function zoom(zoom) {
    if (zoom > 0) {
      zoomLevel += (zoomLevelBefore / 2);
    } else {
      zoomLevel -= (zoomLevelBefore / 2);
    }
    zoomLevelBefore = zoomLevel;
  }
```
